### PR TITLE
✨ ミュートワード一覧テーブルを追加

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,15 @@
   <x-button @click="() => readChatAloud('生成テスト')">
     VoiceQuery生成テスト
   </x-button>
+
+  <suspense>
+    <template #default>
+      <settings-base />
+    </template>
+    <template #fallback>
+      <p>Loading...</p>
+    </template>
+  </suspense>
 </template>
 
 <script lang="ts">
@@ -15,11 +24,13 @@ import client from "./api";
 import type { VoiceQuery, WavBase64 } from "./api/types";
 
 import XButton from "./components/XButton";
+import SettingsBase from './components/SettingsBase.vue';
 
 @Options({
   components: {
     XButton,
-  },
+    SettingsBase,
+  }
 })
 export default class App extends Vue {
   read = false;

--- a/src/components/MuteWordTable/MuteWordTable.vue
+++ b/src/components/MuteWordTable/MuteWordTable.vue
@@ -1,0 +1,26 @@
+<template>
+  <div>
+    <div>
+      <table>
+        <thead>
+          <tr>
+            <th>Mute words</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="item in items" :key="item">
+            <span>{{ item }}</span>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+export default {
+  props: {
+    items: Array,
+  },
+}
+</script>

--- a/src/components/MuteWordTable/index.ts
+++ b/src/components/MuteWordTable/index.ts
@@ -1,0 +1,2 @@
+import View from './MuteWordTable.vue';
+export default View;

--- a/src/components/SettingsBase.vue
+++ b/src/components/SettingsBase.vue
@@ -1,0 +1,72 @@
+<template>
+  <mute-word-table :items="items" />
+
+  <x-button @click="restoreSampleData">
+    <span>ミュートワード: サンプルデータを流し込み</span>
+  </x-button>
+  <x-button @click="clearMuteWords">
+    <span>ミュートワード: データをすべてクリア</span>
+  </x-button>
+</template>
+
+<script lang="ts">
+import { ref } from 'vue';
+import { store } from '@/core/store';
+import XButton from "@/components/XButton";
+
+import MuteWordTable from './MuteWordTable';
+
+type ListData<T> = {
+  items: T[],
+}
+
+type MuteWord = string;
+
+type MuteWords = ListData<MuteWord>;
+
+export default {
+  components: { XButton, MuteWordTable },
+  async setup() {
+    const items = ref(['']);
+    items.value = await loadItems();
+
+    async function loadItems(): Promise<string[]> {
+      await store.load();
+
+      const v = await store.get<MuteWords>('mute-words');
+      if (!v?.items) {
+        return [];
+      }
+      return v.items;
+    }
+
+      const restoreSampleData = async (): Promise<void> => {
+        await store.set('mute-words', { items: ['hello', 'world', '!']});
+        await store.save();
+
+        const v = await store.get<MuteWords>('mute-words');
+        if(!v?.items) {
+          throw new Error('no mute-words');
+        }
+        items.value = v.items;
+      }
+
+      const clearMuteWords = async (): Promise<void> => {
+        await store.set('mute-words', { items: []});
+        await store.save();
+
+        const v = await store.get<MuteWords>('mute-words');
+        if(!v?.items) {
+          throw new Error('no mute-words');
+        }
+        items.value = v.items;
+      }
+
+    return {
+      items,
+      restoreSampleData,
+      clearMuteWords,
+    };
+  },
+}
+</script>

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -1,0 +1,22 @@
+import { Store } from 'tauri-plugin-store-api';
+
+// ここ本当は window を any にしないで window 型をどこかで上書きしたほうが良い
+const isTauri = !!(window as any).__TAURI__
+
+// もし tauri を使わずに serve したとき用のモック
+class StoreMock {
+  async set(key: string, value: unknown): Promise<void> {
+    return;
+  }
+  async get<T>(key: string): Promise<T | null> {
+    return null;
+  }
+  async load(): Promise<void> {
+    return;
+  }
+  async save(): Promise<void> {
+    return;
+  }
+}
+
+export const store = isTauri ? new Store('.settings') : new StoreMock();


### PR DESCRIPTION
## やったこと
- ✨ ミュートワード一覧テーブルを追加

<img width="397" alt="image" src="https://user-images.githubusercontent.com/41379069/183296862-be12b5c9-629a-452e-bd61-c64dcf9861ed.png">

## まだできていないこと

- ミュートワード追加UI
- ミュートワード削除UI

## 確認したこと

- 「ミュートワード: サンプルデータを流し込み」ボタンを押すとサンプルデータが流し込まれる
  - さらにアプリを落として再起動してもデータが保存されている
- 「ミュートワード: データをすべてクリア」ボタンを押すとサンプルデータが流し込まれる
  - さらにアプリを落として再起動してもデータが消えたままになっている

## 補足

https://github.com/tauri-apps/tauri-plugin-store をつかって、application cache folder に `.settings` というファイルにデータを保存しているぽいです。
